### PR TITLE
use a separator token between visual and text embeddings

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -94,10 +94,10 @@ def save_image_and_caption_to_png(folder, image, caption, image_filename):
 
 if __name__ == "__main__":
     image_folder = "input_images"
-    output_folder = "outputs-11-27-2024-0424pm"
+    output_folder = "outputs-11-28-2024-0739pm"
 
     gpt_weights_path = "gpt2.pt"
-    connector_weights_path = "connector_weights_11000.pt"
+    connector_weights_path = "vl_connector.pt"
 
     vision_encoder, preprocess, model, connector, tokenizer = load_models_and_tokenizer(
         gpt_weights_path, connector_weights_path

--- a/gpt.py
+++ b/gpt.py
@@ -156,27 +156,24 @@ class GPT(nn.Module):
         return y
 
     def generate(self, x, visual_embeds=None, max_new_tokens=256, temperature=0.8):
-        if x.size(1) > 0:
-            text_embeds = self.wte(x)
-
-            batch_size, text_len, _ = text_embeds.size()
-            pos_ids = torch.arange(
-                0, text_len, dtype=torch.long, device=text_embeds.device
-            )
-            pos_emb = self.wpe(pos_ids).unsqueeze(0).expand(batch_size, text_len, -1)
-            text_embeds = text_embeds + pos_emb
-        else:
-            text_embeds = None
+        text_embeds = self.wte(x)
+        batch_size, text_len, _ = text_embeds.size()
+        pos_ids = torch.arange(0, text_len, dtype=torch.long, device=text_embeds.device)
+        pos_emb = self.wpe(pos_ids).unsqueeze(0).expand(batch_size, text_len, -1)
+        text_embeds = text_embeds + pos_emb
 
         if visual_embeds is not None:
+            # 0th index is the number of visual embeddings because during inference, batchsize is set to 1
             num_visual_tokens = visual_embeds.size(0)
-            combined_embeds = visual_embeds.unsqueeze(0)
-            seq_len = num_visual_tokens
+            combined_embeds = torch.cat(
+                [visual_embeds.unsqueeze(0), text_embeds], dim=1
+            )
+            seq_len = num_visual_tokens + text_len
             mask = self._create_vision_language_mask(seq_len, num_visual_tokens)
-            seq_len = 0
+            seq_len = text_len
         else:
             combined_embeds = text_embeds
-            seq_len = text_embeds.size(1) if text_embeds is not None else 0
+            seq_len = text_len
             mask = self._create_causal_mask(seq_len)
 
         combined_embeds, cache = self._forward_transformer_blocks(
@@ -281,9 +278,7 @@ def transpose_specific_layers(state_dict):
 def generate_text(
     model: GPT, tokenizer, initial_text="", vision_embeds=None, temperature=0.8
 ):
-    if vision_embeds is not None:
-        x = torch.tensor([[]], device=model.wte.weight.device)
-    elif initial_text:
+    if initial_text:
         x = torch.tensor(
             [tokenizer.encode(initial_text)], device=model.wte.weight.device
         )

--- a/vision_language_connector.py
+++ b/vision_language_connector.py
@@ -2,43 +2,26 @@ import torch.nn as nn
 
 
 class VisionLanguageConnector(nn.Module):
-    def __init__(
-        self,
-        vision_embed_dim=768,
-        language_embed_dim=768,
-        hidden_multiplier=4,
-        num_layers=3,
-        dropout_rate=0.1,
-    ):
+    def __init__(self, vision_embed_dim=768, language_embed_dim=768):
         super(VisionLanguageConnector, self).__init__()
 
         self.vision_embed_dim = vision_embed_dim
-        hidden_dim = self.vision_embed_dim * hidden_multiplier
+        hidden_dim = self.vision_embed_dim * 4
 
-        self.layers = nn.ModuleList()
-        for i in range(num_layers):
-            input_dim = vision_embed_dim if i == 0 else hidden_dim
-            output_dim = language_embed_dim if i == (num_layers - 1) else hidden_dim
-            self.layers.append(
-                nn.Sequential(
-                    nn.LayerNorm(input_dim),
-                    nn.Linear(input_dim, output_dim),
-                    nn.GELU(),
-                    nn.Dropout(dropout_rate),
-                )
-            )
+        self.layers = nn.Sequential(
+            nn.Linear(self.vision_embed_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, language_embed_dim),
+        )
 
     def forward(self, x):
         batch_size, num_visual_tokens, vision_embed_dim = x.shape
 
-        assert (
-            vision_embed_dim == self.vision_embed_dim
-        ), f"Expected vision_embed_dim={self.vision_embed_dim}, got {vision_embed_dim}"
-
+        assert vision_embed_dim == self.vision_embed_dim
+        # Reshape x to [-1, vision_embed_dim] to apply the linear transformation
         x = x.view(-1, vision_embed_dim)
-
-        for layer in self.layers:
-            x = layer(x)
-
+        # Apply the MLP
+        x = self.layers(x)
+        # Reshape back to [batch_size, num_visual_tokens, output_dim]
         x = x.view(batch_size, num_visual_tokens, -1)
         return x

--- a/vision_language_connector.py
+++ b/vision_language_connector.py
@@ -2,26 +2,43 @@ import torch.nn as nn
 
 
 class VisionLanguageConnector(nn.Module):
-    def __init__(self, vision_embed_dim=768, language_embed_dim=768):
+    def __init__(
+        self,
+        vision_embed_dim=768,
+        language_embed_dim=768,
+        hidden_multiplier=4,
+        num_layers=3,
+        dropout_rate=0.1,
+    ):
         super(VisionLanguageConnector, self).__init__()
 
         self.vision_embed_dim = vision_embed_dim
-        hidden_dim = self.vision_embed_dim * 4
+        hidden_dim = self.vision_embed_dim * hidden_multiplier
 
-        self.layers = nn.Sequential(
-            nn.Linear(self.vision_embed_dim, hidden_dim),
-            nn.ReLU(),
-            nn.Linear(hidden_dim, language_embed_dim),
-        )
+        self.layers = nn.ModuleList()
+        for i in range(num_layers):
+            input_dim = vision_embed_dim if i == 0 else hidden_dim
+            output_dim = language_embed_dim if i == (num_layers - 1) else hidden_dim
+            self.layers.append(
+                nn.Sequential(
+                    nn.LayerNorm(input_dim),
+                    nn.Linear(input_dim, output_dim),
+                    nn.GELU(),
+                    nn.Dropout(dropout_rate),
+                )
+            )
 
     def forward(self, x):
         batch_size, num_visual_tokens, vision_embed_dim = x.shape
 
-        assert vision_embed_dim == self.vision_embed_dim
-        # Reshape x to [-1, vision_embed_dim] to apply the linear transformation
+        assert (
+            vision_embed_dim == self.vision_embed_dim
+        ), f"Expected vision_embed_dim={self.vision_embed_dim}, got {vision_embed_dim}"
+
         x = x.view(-1, vision_embed_dim)
-        # Apply the MLP
-        x = self.layers(x)
-        # Reshape back to [batch_size, num_visual_tokens, output_dim]
+
+        for layer in self.layers:
+            x = layer(x)
+
         x = x.view(batch_size, num_visual_tokens, -1)
         return x


### PR DESCRIPTION
- adding an <|endoftext|> token to separate visual and textual embeddings improves caption quality